### PR TITLE
feat: add version info (commit hash) to footer

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,9 +11,14 @@ const getGitCommitHash = () => {
   }
 }
 
+// Get app version from environment variable or fall back to git commit hash
+const getAppVersion = () => {
+  return process.env.APP_VERSION || getGitCommitHash()
+}
+
 const nextConfig: NextConfig = {
   env: {
-    NEXT_PUBLIC_GIT_COMMIT_HASH: getGitCommitHash(),
+    NEXT_PUBLIC_APP_VERSION: getAppVersion(),
   },
 }
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,20 @@
+import { execSync } from 'child_process'
 import type { NextConfig } from 'next'
 
+// Get git commit hash at build time
+const getGitCommitHash = () => {
+  try {
+    return execSync('git rev-parse --short HEAD').toString().trim()
+  } catch (error) {
+    console.warn('Could not get git commit hash:', error)
+    return 'unknown'
+  }
+}
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  env: {
+    NEXT_PUBLIC_GIT_COMMIT_HASH: getGitCommitHash(),
+  },
 }
 
 export default nextConfig

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import '@/app/globals.css'
 import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
 
+import { Footer } from '@/components/Footer'
+
 const geistSans = Geist({
   variable: '--font-geist-sans',
   subsets: ['latin'],
@@ -26,9 +28,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased flex min-h-screen flex-col`}
       >
         {children}
+        <Footer />
       </body>
     </html>
   )

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,14 @@
+export function Footer() {
+  const commitHash = process.env.NEXT_PUBLIC_GIT_COMMIT_HASH || 'dev'
+
+  return (
+    <footer className="mt-auto border-t bg-gray-50">
+      <div className="container mx-auto px-4 py-4">
+        <div className="flex items-center justify-between text-sm text-gray-600">
+          <div>© 2025 Tasker</div>
+          <div className="font-mono">version: {commitHash}</div>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,12 +1,12 @@
 export function Footer() {
-  const commitHash = process.env.NEXT_PUBLIC_GIT_COMMIT_HASH || 'dev'
+  const version = process.env.NEXT_PUBLIC_APP_VERSION || 'dev'
 
   return (
     <footer className="mt-auto border-t bg-gray-50">
       <div className="container mx-auto px-4 py-4">
         <div className="flex items-center justify-between text-sm text-gray-600">
           <div>© 2025 Tasker</div>
-          <div className="font-mono">version: {commitHash}</div>
+          <div className="font-mono">version: {version}</div>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Why

- Users and developers need to quickly identify which version of the application is currently deployed
- Having the commit hash visible helps with debugging and support issues

## What

- The footer now displays the Git commit hash as version information
- The commit hash is captured at build time through Next.js configuration
- A new Footer component is added to the application layout with proper styling

🤖 Generated with [Claude Code](https://claude.ai/code)